### PR TITLE
fix(pie): fix pie chart label display

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,25 @@ Example:
 ```bash
 git commit -m "ci(semantic-release): add commitlint and husky as dev tools to write valid commits"
 ```
+
+## Local development
+For local development in a React/Recharts app that uses bento-charts, you can follow these steps for your setup:
+
+1. `build` and `pack` bento-charts
+```bash
+# Builds package and creates a pack file in the "./packs" dir
+npm run buildpack
+```
+
+2. In the project using bento-charts, modify the bento-charts dependency in package.json so that the version number is now the absolute path to the pack file.
+```diff
+- "bento-charts": "2.0.0",
++ "bento-charts": "file:~/bento-charts/packs/bento-charts-2.0.0.tgz",
+```
+
+3. Install the dependencies in the project
+```bash
+npm install
+```
+
+**Note: you will need to repeat steps 1 and 3 everytime you want the changes to be applied to the app using bento-charts**

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "npx tsc",
     "prepublishOnly": "npm run build",
-    "lint": "npx eslint src/**"
+    "lint": "npx eslint src/**",
+    "buildpack": "npx tsc && npm pack --pack-destination ./packs"
   },
   "release": {
     "branches": [

--- a/packs/.gitignore
+++ b/packs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/Charts/BentoPie.tsx
+++ b/src/Charts/BentoPie.tsx
@@ -120,6 +120,8 @@ const BentoPie = ({
 const toNumber = (val: number | string | undefined, defaultValue?: number): number => {
   if (val && typeof val === "string") {
     return Number(val);
+  } else if (val && typeof val === "number") {
+    return val
   }
   return defaultValue || 0;
 };

--- a/src/Charts/BentoPie.tsx
+++ b/src/Charts/BentoPie.tsx
@@ -121,7 +121,7 @@ const toNumber = (val: number | string | undefined, defaultValue?: number): numb
   if (val && typeof val === "string") {
     return Number(val);
   } else if (val && typeof val === "number") {
-    return val
+    return val;
   }
   return defaultValue || 0;
 };


### PR DESCRIPTION
An type handling error in the BentoPie toNumber function caused label anchors to always be at (0, 0) rather than the real arguments passed.